### PR TITLE
add default notification template for development

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,49 @@
+module NotificationsHelper
+end
+
+class NotificationRenderer
+  attr_reader :view_context, :notification
+
+  def initialize(view_context, notification)
+    @view_context = view_context
+    @notification = notification
+  end
+
+  def render_or_stub
+    if Rails.env.development? && template_missing?
+      generate_template
+    end
+
+    view_context.render "notifications/#{notification.notifiable_type.underscore}/#{notification.action.parameterize.underscore}",
+      actor: notification.actor,
+      action: notification.action,
+      notifiable: notification.notifiable
+  end
+
+  private
+
+  def template_missing?
+    !view_context.lookup_context.exists?(
+      "#{notification.action}",
+      ["notifications/#{notification.notifiable_type.underscore}"],
+      true
+    )
+  end
+
+  def generate_template
+    dir_name = "app/views/notifications/#{notification.notifiable_type.underscore}"
+    FileUtils.mkdir_p(dir_name)
+
+    full_path = "#{dir_name}/_#{notification.action.parameterize.underscore}.html.erb"
+    template = File.new(full_path, "wb")
+    template.puts default_notification
+    template.close
+  end
+
+  def default_notification
+    <<~'NOTICE'
+      <%# Available variables: actor, action, notifiable %>
+      <%= "#{actor.name} #{action} #{notifiable}" %>
+    NOTICE
+  end
+end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,6 +2,8 @@
 
 <ul>
   <% @notifications.each do |notification| %>
-    <li><%= render "notifications/#{notification.notifiable_type.underscore}/#{notification.action.underscore}", actor: notification.actor, notifiable: notification.notifiable  %></li>
+    <li>
+      <%= NotificationRenderer.new(self, notification).render_or_stub %>
+    </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Here is my solution for the default notification template. 

Please let me know if I forgot anything, or if any changes need to be made. Any feedback is appreciated.

I left the `NotificationsHelper` module in place and added the `NotificationRenderer` class below. I'm sure we'll want to move this into `lib` or somewhere else more appropriate.

-Scott

