### PR TITLE
add pswd to user dash

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -148,6 +148,14 @@ def add_administrate
     /announcement_type: Field::String/,
     "announcement_type: Field::Select.with_options(collection: Announcement::TYPES)"
 
+  gsub_file "app/dashboards/user_dashboard.rb",
+    /email: Field::String/,
+    "email: Field::String,\n\t\tpassword: Field::String"
+
+  gsub_file "app/dashboards/user_dashboard.rb",
+    /FORM_ATTRIBUTES = \[/,
+    "FORM_ATTRIBUTES = [\n\t\t:password,"
+
   gsub_file "app/controllers/admin/application_controller.rb",
     /# TODO Add authentication logic here\./,
     "redirect_to '/', alert: 'Not authorized.' unless user_signed_in? && current_user.admin?"


### PR DESCRIPTION
Simple addition of a password field to the user dashboard.  I think a more user friendly page layout would be better, but for a *template* perhaps this simple addition is best and leave the page layout to the user of the template.