### PR TITLE
Fix wrong number of arguments error in icon in Masquerade

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <% if user_masquerade? %>
   <div class="alert alert-warning text-center">
     You're logged in as <b><%= current_user.name %> (<%= current_user.email %>)</b>
-    <%= link_to back_masquerade_path(current_user) do %><%= icon("times") %> Logout <% end %>
+    <%= link_to back_masquerade_path(current_user) do %><%= icon("fas", "times") %> Logout <% end %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Fixes the wrong number of arguments error (gem font-awesome now requires the syntax to be <%= icon('fas','nameOfIcon') %>). Before this change it raises an exception (wrong number of arguments: given 1, expected 2 .. 4) when masquerading an user. 