### PR TITLE
Use bigint instead of integer for reference column types

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -140,7 +140,7 @@ def add_announcements
 end
 
 def add_notifications
-  generate "model Notification recipient_id:integer actor_id:integer read_at:datetime action:string notifiable_id:integer notifiable_type:string"
+  generate "model Notification recipient_id:bigint actor_id:bigint read_at:datetime action:string notifiable_id:bigint notifiable_type:string"
   route "resources :notifications, only: [:index]"
 end
 


### PR DESCRIPTION
A while ago Rails switched to `bigint` as the default primary key type: https://github.com/rails/rails/pull/26266

I noticed that the the `notifications` table is using FKs of type `integer` when the primary keys they point to are actually `bigint`s (due to the above mentioned change).

I think it's best if they are the same and here's a lame post I threw together explaining why: http://ruby.zigzo.com/2018/08/29/foreign-key-column-types/

Thanks!