### PR TITLE
Use the new credentials API in Rails 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ development:
   github:
     app_id: something
     app_secret: something
+    options:
+      scope: 'user:email'
+      whatever: true
 production:
   github:
     app_id: something
     app_secret: something
+    options:
+      scope: 'user:email'
+      whatever: true
 ```
 
 With the environment, the service and the app_id/app_secret. If this is done correctly, you should see login links

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ Or if you have downloaded this repo, you can reference template.rb locally:
 rails new myapp -d postgresql -m template.rb
 ```
 
+#### Authenticate with social networks
+
+We use the encrypted Rails Credentials for app_id and app_secrets when it comes to omniauth authentication. Edit them as so:
+
+```
+EDITOR=vim rails credentials:edit
+```
+
+Make sure your file follow this structure:
+
+```
+secret_key_base: [your-key]
+development:
+  github:
+    app_id: something
+    app_secret: something
+production:
+  github:
+    app_id: something
+    app_secret: something
+```
+
+With the environment, the service and the app_id/app_secret. If this is done correctly, you should see login links
+for the services you have added to the encrypted credentials using `EDITOR=vim rails credentials:edit`
+
 #### Cleaning up
 
 ```bash

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,7 +1,9 @@
 class Service < ApplicationRecord
   belongs_to :user
 
-  %w{ facebook twitter github }.each do |provider|
+  PROVIDERS = %w{ facebook twitter github }
+
+  PROVIDERS.each do |provider|
     scope provider, ->{ where(provider: provider) }
   end
 

--- a/template.rb
+++ b/template.rb
@@ -184,17 +184,12 @@ def add_multiple_authentication
     generate "model Service user:references provider uid access_token access_token_secret refresh_token expires_at:datetime auth:text"
 
     template = """
-  if facebook = Rails.application.credentials[Rails.env.to_sym][:facebook]
-    config.omniauth :facebook, facebook[:app_id], facebook[:app_secret], scope: 'email,user_posts'
-  end
-
-  if twitter = Rails.application.credentials[Rails.env.to_sym][:twitter]
-    config.omniauth :twitter, twitter[:app_id], twitter[:app_secret]
-  end
-
-  if github = Rails.application.credentials[Rails.env.to_sym][:github]
-    config.omniauth :github, github[:app_id], github[:app_secret}
-  end
+    env_creds = Rails.application.credentials[Rails.env.to_sym]
+    Service::PROVIDERS.each do |provider|
+      if options = env_creds[provider]
+        confg.omniauth provider, options[:app_id], options[:app_secret], options.fetch(:options, {})
+      end
+    end
     """.strip
 
     insert_into_file "config/initializers/devise.rb", "  " + template + "\n\n",

--- a/template.rb
+++ b/template.rb
@@ -184,16 +184,16 @@ def add_multiple_authentication
     generate "model Service user:references provider uid access_token access_token_secret refresh_token expires_at:datetime auth:text"
 
     template = """
-  if Rails.application.secrets.facebook_app_id.present? && Rails.application.secrets.facebook_app_secret.present?
-    config.omniauth :facebook, Rails.application.secrets.facebook_app_id, Rails.application.secrets.facebook_app_secret, scope: 'email,user_posts'
+  if facebook = Rails.application.credentials[Rails.env.to_sym][:facebook]
+    config.omniauth :facebook, facebook[:app_id], facebook[:app_secret], scope: 'email,user_posts'
   end
 
-  if Rails.application.secrets.twitter_app_id.present? && Rails.application.secrets.twitter_app_secret.present?
-    config.omniauth :twitter, Rails.application.secrets.twitter_app_id, Rails.application.secrets.twitter_app_secret
+  if twitter = Rails.application.credentials[Rails.env.to_sym][:twitter]
+    config.omniauth :twitter, twitter[:app_id], twitter[:app_secret]
   end
 
-  if Rails.application.secrets.github_app_id.present? && Rails.application.secrets.github_app_secret.present?
-    config.omniauth :github, Rails.application.secrets.github_app_id, Rails.application.secrets.github_app_secret
+  if github = Rails.application.credentials[Rails.env.to_sym][:github]
+    config.omniauth :github, github[:app_id], github[:app_secret}
   end
     """.strip
 


### PR DESCRIPTION
Rails.application.secrets will soon be deprecated. Let's leverage the
new credentials way of doing things that comes with Rails 5.2 (https://github.com/rails/rails/pull/30067)

I've proposed a structure that checks the current environment - so you can have unique secrets for development and production:

```
development:
  github:
    app_id:
    secret:
  facebook:
    app_id:
    secret:
  twitter:
    app_id:
    secret:
production:
  github:
    app_id:
    secret:
  facebook:
    app_id:
    secret:
  twitter:
    app_id:
    secret:
```