### PR TITLE
fix omniauth link generation.

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -213,7 +213,7 @@ def add_multiple_authentication
 
     template = """
     env_creds = Rails.application.credentials[Rails.env.to_sym] || {}
-    %w{ facebook twitter github }.each do |provider|
+    %i{ facebook twitter github }.each do |provider|
       if options = env_creds[provider]
         config.omniauth provider, options[:app_id], options[:app_secret], options.fetch(:options, {})
       end


### PR DESCRIPTION
This patch will fix automatic generation of Omniauth links on the 'Sign Up' & 'Login' pages.

The current implementation is checking entries in `Rails.application.credentials` against an Array of Strings but the keys of the credential providers are presented as Symbols. This patch will check against an Array of Symbols