### PR TITLE
removed glyph icon reference

### DIFF
--- a/lib/templates/erb/scaffold/show.html.erb
+++ b/lib/templates/erb/scaffold/show.html.erb
@@ -1,10 +1,8 @@
 <div class="page-header">
   <%%= link_to <%= index_helper %>_path, class: 'btn btn-default' do %>
-    <span class="glyphicon glyphicon-list-alt"></span>
     All <%= plural_table_name.capitalize %>
   <%% end %>
   <%%= link_to edit_<%= singular_table_name %>_path(@<%= singular_table_name %>), class: 'btn btn-primary' do %>
-    <span class="glyphicon glyphicon-pencil"></span>
     Edit
   <%% end %>
   <h1>Show <%= singular_table_name %></h1>


### PR DESCRIPTION
glyph icons are not currently in this build but were referenced in the show scaffold template.