### PR TITLE
Fontawesome flag reference updated.

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,7 +23,7 @@
 
         <li class="nav-item">
           <%= link_to notifications_path, class: "nav-link" do %>
-            <span><i class="fa fa-flag-o" aria-hidden="true"></i></span>
+            <span><i class="far fa-flag" aria-hidden="true"></i></span>
           <% end %>
          </li>
 


### PR DESCRIPTION
Updates the Fontawesome flag icon for the notifications in the navbar.

**Problem**
Notification icon does not show in the navbar.

**Solution**
Updated reference to appropriate Fontawsome icon.