### PR TITLE
Rescue from git configuration exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2020-10-24
+
+* Rescue from git configuration exception
+
 ### 2020-08-20
 
 * Add tests for generating postgres and mysql apps

--- a/template.rb
+++ b/template.rb
@@ -290,7 +290,12 @@ after_bundle do
   unless ENV["SKIP_GIT"]
     git :init
     git add: "."
-    git commit: %Q{ -m 'Initial commit' }
+    # git commit will fail if user.email is not configured
+    begin
+      git commit: %( -m 'Initial commit' )
+    rescue StandardError => e
+      puts e.message
+    end
   end
 
   say


### PR DESCRIPTION
Rescue errors when committing to git if `user.email` is not configured.
