### PR TITLE
Update Devise View Error Handing

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-center">Account</h1>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="form-group">
         <%= f.text_field :name, autofocus: false, class: 'form-control', placeholder: "Full Name" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-center">Sign Up</h1>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="form-group">
         <%= f.text_field :name, autofocus: true, class: 'form-control', placeholder: "Full Name" %>


### PR DESCRIPTION
Howdy,

I have edited the error handling partials after removing the deprecated features from the views.

Devise is changing how error handling works in the next major version. Instead of using `<%= devise_error_messages! %>`, we are now told to use `<%= render "devise/shared/error_messages", resource: resource %>`