### PR TITLE
Use stable version of the Administrate gem

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -38,7 +38,7 @@ def rails_6?
 end
 
 def add_gems
-  gem 'administrate', github: "excid3/administrate", branch: 'jumpstart'
+  gem 'administrate'
   gem 'bootstrap', '~> 4.5'
   gem 'devise', '~> 4.7', '>= 4.7.1'
   gem 'devise-bootstrapped', github: 'excid3/devise-bootstrapped', branch: 'bootstrap4'


### PR DESCRIPTION
@excid3's `Administrate` jumpstart gem unknowingly broke the functionality of the install generator of the gem. As a temporary solution, I have moved the gem into the most recent version to fast-forward with the fixes.