### PR TITLE
Update _error_messages.html.erb

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="alert alert-danger">
+  <div class="alert alert-danger">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,


### PR DESCRIPTION
The bootstrap alert classes were being applied to the id attribute instead of the class attribute of the div.  Saw this in your hotwire/devise gorails video.