### PR TITLE
Use devise lookup method

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -51,6 +51,7 @@ module Users
       else
         @user = User.find_for_authentication(email: auth.info.email) || create_user
       end
+    end
 
     def service_attrs
       expires_at = auth.credentials.expires_at.present? ? Time.at(auth.credentials.expires_at) : nil

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -48,14 +48,9 @@ module Users
         @user = current_user
       elsif service.present?
         @user = service.user
-      elsif User.where(email: auth.info.email).any?
-        # 5. User is logged out and they login to a new account which doesn't match their old one
-        flash[:alert] = "An account with this email already exists. Please sign in with that account before connecting your #{auth.provider.titleize} account."
-        redirect_to new_user_session_path
       else
-        @user = create_user
+        @user = User.find_for_authentication(email: auth.info.email) || create_user
       end
-    end
 
     def service_attrs
       expires_at = auth.credentials.expires_at.present? ? Time.at(auth.credentials.expires_at) : nil


### PR DESCRIPTION
# Dont interrupt omniauth if user exists 

Use devise lookup method to set user properly in Devise::OmniauthCallbacksController.
No need to sign in with that other account.
