### PR TITLE
Use madmin_root_path instead of admin_root_path

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -32,8 +32,8 @@
               <%= image_tag avatar_path(current_user, size: 40), height: 20, width: 20, class: "rounded" %>
             <% end %>
             <div id="nav-account-dropdown" class="dropdown-menu dropdown-menu-right" aria-labelledby="navbar-dropdown">
-              <% if current_user.admin? && respond_to?(:admin_root_path) %>
-                <%= link_to "Admin Area", admin_root_path, class: "dropdown-item" %>
+              <% if current_user.admin? && respond_to?(:madmin_root_path) %>
+                <%= link_to "Admin Area", madmin_root_path, class: "dropdown-item" %>
               <% end %>
               <%= link_to "Settings", edit_user_registration_path, class: "dropdown-item" %>
               <div class="dropdown-divider"></div>


### PR DESCRIPTION
Switched from Administrate to Madmin in
6c512b7050a369e38809ecb56f883b693b116af6 and there is no longer a path
for `admin_root_path`. Madmin uses `madmin_root_path`. Updating the
navbar to reflect that.