### PR TITLE
Conditional for notices partial

### DIFF
--- a/app/views/shared/_notices.html.erb
+++ b/app/views/shared/_notices.html.erb
@@ -1,8 +1,10 @@
-<div class="container mx-auto">
-  <% flash.each do |msg_type, message| %>
-    <div class="alert <%= bootstrap_class_for(msg_type) %> alert-dismissible fade show" role="alert">
-      <%= message %>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-  <% end %>
-</div>
+<% if !flash.empty? %>
+  <div class="container mx-auto">
+    <% flash.each do |msg_type, message| %>
+      <div class="alert <%= bootstrap_class_for(msg_type) %> alert-dismissible fade show" role="alert">
+        <%= message %>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
adding a conditional for flash message container so that it does not render when there are no messages

Not sure if this is the proper procedure for a pull request, but I wanted to add this so that the container does not render if there are no flash messages present.  I noticed that it makes a big empty space on the page otherwise.  

