### PR TITLE
Skip Webpacker configuration for Rails 7

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -143,7 +143,7 @@ def add_webpack
   # Rails 6+ comes with webpacker by default, so we can skip this step
   return if rails_6?
   # Rails 7 won't be using webpacker
-  return if rails_7?
+  return if rails_7? || master?
   # Our application layout already includes the javascript_pack_tag,
   # so we don't need to inject it
   rails_command 'webpacker:install'
@@ -156,6 +156,9 @@ def add_javascript
     run "yarn add @rails/actioncable@pre @rails/actiontext@pre @rails/activestorage@pre @rails/ujs@pre"
   end
 
+  # Rails 7 won't be using webpacker
+  return if rails_7? || master?
+  
   content = <<-JS
 const webpack = require('webpack')
 environment.plugins.append('Provide', new webpack.ProvidePlugin({

--- a/template.rb
+++ b/template.rb
@@ -143,7 +143,8 @@ def add_webpack
   # Rails 6+ comes with webpacker by default, so we can skip this step
   return if rails_6?
   # Rails 7 won't be using webpacker
-  return if rails_7? || master?
+  return if rails_7?
+  return if master?
   # Our application layout already includes the javascript_pack_tag,
   # so we don't need to inject it
   rails_command 'webpacker:install'
@@ -157,7 +158,8 @@ def add_javascript
   end
 
   # Rails 7 won't be using webpacker
-  return if rails_7? || master?
+  return if rails_7?
+  return if master?
   
   content = <<-JS
 const webpack = require('webpack')

--- a/template.rb
+++ b/template.rb
@@ -142,7 +142,8 @@ end
 def add_webpack
   # Rails 6+ comes with webpacker by default, so we can skip this step
   return if rails_6?
-
+  # Rails 7 won't be using webpacker
+  return if rails_7?
   # Our application layout already includes the javascript_pack_tag,
   # so we don't need to inject it
   rails_command 'webpacker:install'


### PR DESCRIPTION
Template installation fails at "The file .../myapp/config/webpack/environment.js does not appear to exist"  because it's trying to update webpack configuration files which aren't relevant in Rails 7+.