### PR TITLE
Rescue error for npm < 7.1

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -243,7 +243,12 @@ end
 
 def add_esbuild_script
   build_script = "node esbuild.config.js"
-  run %(npm set-script build:css "#{build_script}")
+
+  if (`npx -v`.to_f < 7.1 rescue "Missing")
+    say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green
+  else
+    run %(npm set-script build:css "#{build_script}")
+  end
 end
 
 def add_esbuild_imports


### PR DESCRIPTION
Am still running on npm 6. Hope am not alone

Reference https://github.com/rails/jsbundling-rails/blob/8b4d2a95bc4bf5c5d590813242ac8f0aee0567fc/lib/install/esbuild/install.rb#L7
