### PR TITLE
Fixes build script in package.json

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -247,7 +247,7 @@ def add_esbuild_script
   if (`npx -v`.to_f < 7.1 rescue "Missing")
     say %(Add "scripts": { "build": "#{build_script}" } to your package.json), :green
   else
-    run %(npm set-script build:css "#{build_script}")
+    run %(npm set-script build "#{build_script}")
   end
 end
 


### PR DESCRIPTION
Before the `build:css` command was being overwritten by the esbuild script.
Now the `build` script will point to the esbuild script, leaving the `build:css` command to build the CSS assets.