### PR TITLE
Run `yarn build` as part of tests

### DIFF
--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -10,10 +10,15 @@ class TemplateTest < Minitest::Test
   end
 
   def test_generator_succeeds
-    output, err = capture_subprocess_io do
+    output, _err = capture_subprocess_io do
       system("DISABLE_SPRING=1 SKIP_GIT=1 rails new test_app -m template.rb")
     end
     assert_includes output, "Jumpstart app successfully created!"
+
+    output, _err = capture_subprocess_io do
+      system("cd test_app && yarn build")
+    end
+    assert_includes output, "Done in "
   end
 
   # TODO: Fix these tests on CI so they don't fail on db:create


### PR DESCRIPTION
I think the problem I encountered in #171 could have been caught if `yarn build` ran as part of the tests.

I've implemented this as a test following the style of the existing ones, but checking the exit code of `yarn build` may be more appropriate.