### PR TITLE
removed   gem 'image_processing' from #add_gems

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -40,7 +40,6 @@ def add_gems
 
   gem 'devise', '~> 4.8', '>= 4.8.0'
   gem 'friendly_id', '~> 5.4'
-  gem 'image_processing'
   gem 'jsbundling-rails'
   gem 'madmin'
   gem 'name_of_person', '~> 1.1'


### PR DESCRIPTION
  Removed   "gem 'image_processing'" from #add_gems because it's already in the Gemfile before #add_gems is run.  Having image_processing mentioned twice in the Gemfile is causing errors.