### PR TITLE
Add x86_64-linux as a platform for Bundler

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -248,7 +248,8 @@ after_bundle do
   add_announcements_css
   add_esbuild_script
   rails_command "active_storage:install"
-  
+
+  # Make sure Linux is in the Gemfile.lock for deploying
   run "bundle lock --add-platform x86_64-linux"
 
   copy_templates

--- a/template.rb
+++ b/template.rb
@@ -248,6 +248,8 @@ after_bundle do
   add_announcements_css
   add_esbuild_script
   rails_command "active_storage:install"
+  
+  run "bundle lock --add-platform x86_64-linux"
 
   copy_templates
 


### PR DESCRIPTION
Unless you're developing an Intel-based Linux machine, the first deploy to Hatchbox or Heroku will likely fail with an error such as:

```
Your bundle only supports platforms ["arm64-darwin-21"] but your local platform
is x86_64-linux. Add the current platform to the lockfile with `bundle lock
--add-platform x86_64-linux` and try again.
```

I've added a step to run the necessary `bundle` command.

I realize that if Hatchbox or Heroku move to a different architecture in future then approach this may no longer be viable.