### PR TITLE
Update Pundit include

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   impersonates :user
-  include Pundit
+  include Pundit::Authorization
 
   protect_from_forgery with: :exception
 


### PR DESCRIPTION
The old usage was deprecated in 2.2.0 (Feb 2022) and now emits a warning, see [changelog](https://github.com/varvet/pundit/blob/main/CHANGELOG.md).

```
DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
```