### PR TITLE
Re-order instructions

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -281,8 +281,8 @@ after_bundle do
   say
   say "  # Update config/database.yml with your database credentials"
   say
-  say "  rails db:create db:migrate"
   say "  rails g noticed:model"
+  say "  rails db:create db:migrate"
   say "  rails g madmin:install # Generate admin dashboards"
   say "  gem install foreman"
   say "  bin/dev"


### PR DESCRIPTION
Re-order the instructions so that you only have to migrate once because noticed:model requires a migration.