### PR TITLE
Re-order post install instructions

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -279,6 +279,8 @@ after_bundle do
     end
   end
 
+  rails_command "db:create"
+
   say
   say "Jumpstart app successfully created!", :blue
   say
@@ -286,9 +288,9 @@ after_bundle do
   say "  cd #{original_app_name}"
   say
   say "  # Update config/database.yml with your database credentials"
-  say
-  say "  rails db:create db:migrate"
+
   say "  rails g noticed:model"
+  say "  rails db:migrate"
   say "  rails g madmin:install # Generate admin dashboards"
   say "  gem install foreman"
   say "  bin/dev"

--- a/template.rb
+++ b/template.rb
@@ -287,8 +287,8 @@ after_bundle do
   say
   say "  # Update config/database.yml with your database credentials"
   say
-  say "  rails g noticed:model"
   say "  rails db:create db:migrate"
+  say "  rails g noticed:model"
   say "  rails g madmin:install # Generate admin dashboards"
   say "  gem install foreman"
   say "  bin/dev"

--- a/template.rb
+++ b/template.rb
@@ -279,8 +279,6 @@ after_bundle do
     end
   end
 
-  rails_command "db:create"
-
   say
   say "Jumpstart app successfully created!", :blue
   say
@@ -289,6 +287,7 @@ after_bundle do
   say
   say "  # Update config/database.yml with your database credentials"
 
+  say "  rails db:create"
   say "  rails g noticed:model"
   say "  rails db:migrate"
   say "  rails g madmin:install # Generate admin dashboards"


### PR DESCRIPTION
Re-orders post-install instructions to create DB prior to running the noticed generator.

Running the instructions as-is raises a `PG::ConnectionBad` database "jumpstart_development" does not exist error .

I agree with the changes in #191 to only have to migrate once, but running the noticed generator returns 

`1. Run "rails db:migrate"` 

as one of the Next Steps along with the option to run the pending migrations in the browser so this seems like a clearer approach.