### PR TITLE
Update esbuild configuration for HMR

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bin/rails server -p 3000
 worker: bundle exec sidekiq
-js: yarn build --watch
+js: yarn build --reload
 css: yarn build:css --watch

--- a/template.rb
+++ b/template.rb
@@ -92,7 +92,7 @@ def default_to_esbuild
 end
 
 def add_javascript
-  run "yarn add local-time esbuild-rails trix @hotwired/stimulus @hotwired/turbo-rails @rails/activestorage @rails/ujs @rails/request.js"
+  run "yarn add local-time esbuild-rails trix @hotwired/stimulus @hotwired/turbo-rails @rails/activestorage @rails/ujs @rails/request.js chokidar"
 end
 
 def copy_templates


### PR DESCRIPTION
@excid3 While working on a project this weekend with Jumpstart, I noticed that the HMR was not working. These small changes, based on my testing, should fix the problem:
- Update `Procfile.dev`
- The `chokidar` package was missing

Thanks for a great product.