### PR TITLE
Update Rails version check if Rails 7 or newer is not being used.

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -162,7 +162,7 @@ def add_multiple_authentication
 
   generate "model Service user:references provider uid access_token access_token_secret refresh_token expires_at:datetime auth:text"
 
-  template = "" "
+  template = """
   env_creds = Rails.application.credentials[Rails.env.to_sym] || {}
   %i{ facebook twitter github }.each do |provider|
     if options = env_creds[provider]

--- a/template.rb
+++ b/template.rb
@@ -29,8 +29,14 @@ def rails_version
   @rails_version ||= Gem::Version.new(Rails::VERSION::STRING)
 end
 
-def rails_6_or_newer?
-  Gem::Requirement.new(">= 6.0.0.alpha").satisfied_by? rails_version
+def rails_7_or_newer?
+  Gem::Requirement.new(">= 7.0.0.alpha").satisfied_by? rails_version
+end
+
+unless rails_7_or_newer?
+  say "\nJumpstart requires Rails 7 or newer. You are using #{rails_version}.", :green
+  say "Please remove partially installed Jumpstart files #{original_app_name} and try again.", :green
+  exit 1
 end
 
 def add_gems
@@ -206,10 +212,6 @@ end
 
 def gem_exists?(name)
   IO.read("Gemfile") =~ /^\s*gem ['"]#{name}['"]/
-end
-
-unless rails_6_or_newer?
-  puts "Please use Rails 6.0 or newer to create a Jumpstart application"
 end
 
 # Main setup

--- a/template.rb
+++ b/template.rb
@@ -169,7 +169,7 @@ def add_multiple_authentication
       config.omniauth provider, options[:app_id], options[:app_secret], options.fetch(:options, {})
     end
   end
-  " "".strip
+  """.strip
 
   insert_into_file "config/initializers/devise.rb", "  " + template + "\n\n", before: "  # ==> Warden configuration"
 end


### PR DESCRIPTION
@excid3 This removes Rails 6 installs #198 :
- Checked the method `rails_7_or_newer?` sooner so we can exit out before the install gets too far
- Included an error message and a note to delete the partial install directory

**One edge case**
We are not checking if the user overrides the default system Rails version: `rails _6.1.7_ new appname ...`. 

