### PR TITLE
add add_javascript yarn with --ignore-engines

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -92,7 +92,7 @@ def default_to_esbuild
 end
 
 def add_javascript
-  run "yarn add local-time esbuild-rails trix @hotwired/stimulus @hotwired/turbo-rails @rails/activestorage @rails/ujs @rails/request.js chokidar"
+  run "yarn add local-time esbuild-rails trix @hotwired/stimulus @hotwired/turbo-rails @rails/activestorage @rails/ujs @rails/request.js chokidar --ignore-engines"
 end
 
 def copy_templates


### PR DESCRIPTION
`--ignore-engines` This is to fix the issue when Yarn cannot proceed due to an incompatible Node version.
