### PR TITLE
Relax watchDirectories glob

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -22,7 +22,7 @@ const entryPoints = [
 ]
 const watchDirectories = [
   "./app/javascript/**/*.js",
-  "./app/views/**/*.html*.erb",
+  "./app/views/**/*.erb",
   "./app/assets/builds/**/*.css", // Wait for cssbundling changes
 ]
 const config = {

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -22,7 +22,7 @@ const entryPoints = [
 ]
 const watchDirectories = [
   "./app/javascript/**/*.js",
-  "./app/views/**/*.html.erb",
+  "./app/views/**/*.html*.erb",
   "./app/assets/builds/**/*.css", // Wait for cssbundling changes
 ]
 const config = {


### PR DESCRIPTION
The previous glob was a little too restrictive and would not watch files targeted at request variants e.g. `app/views/things/show.html+phone.erb`