### PR TITLE
Use name_of_person from github directly to avoid Rails 7 bug

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -51,7 +51,7 @@ def add_gems
   add_gem 'friendly_id', '~> 5.4'
   add_gem 'jsbundling-rails'
   add_gem 'madmin'
-  add_gem 'name_of_person', '~> 1.1'
+  add_gem 'name_of_person', github: 'basecamp/name_of_person', branch: 'master'
   add_gem 'noticed', '~> 1.4'
   add_gem 'omniauth-facebook', '~> 8.0'
   add_gem 'omniauth-github', '~> 2.0'


### PR DESCRIPTION
name_of_person currently has a FIX in its repo which handles a Rails 7 bug and is not yet released as a version.

This fix uses the the gem from github directly.